### PR TITLE
fix: correct node sdk package name

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ example/**/dist/
 example/**/build/
 example/**/coverage/
 lib/
+CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ For documentation related to flags management in Bucketeer, refer to the [Bucket
 ## Installation
 
 ```bash
-npm install @bucketeer/openfeature-node-server-sdk @openfeature/server-sdk @bucketeer/node-server-sdk
+npm install @bucketeer/openfeature-node-server-sdk @openfeature/server-sdk @bucketeer/node-server-sdk @openfeature/core
 ```
 
 **Note:** This package requires `@openfeature/server-sdk` and `@bucketeer/node-server-sdk` as peer dependencies.
+
+`@openfeature/server-sdk` requires `@openfeature/core` as a peer dependency.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ For documentation related to flags management in Bucketeer, refer to the [Bucket
 ## Installation
 
 ```bash
-npm install @bucketeer/openfeature-node-server-sdk
+npm install @bucketeer/openfeature-node-server-sdk @openfeature/server-sdk @bucketeer/node-server-sdk
 ```
 
-This will automatically install the required peer dependencies: `@openfeature/server-sdk` and `@bucketeer/node-server-sdk`.
+**Note:** This package requires `@openfeature/server-sdk` and `@bucketeer/node-server-sdk` as peer dependencies.
 
 ## Usage
 

--- a/e2e/localEvaluate.test.ts
+++ b/e2e/localEvaluate.test.ts
@@ -42,6 +42,7 @@ describe('BucketeerProvider - evaluation', () => {
 
     const client = OpenFeature.getClient();
     expect(client.metadata.providerMetadata.name).toBe('Bucketeer Provider');
+    expect(SDK_VERSION).toBeDefined();
     expect(client.metadata.providerMetadata.version).toBe(SDK_VERSION);
     expect(client.providerStatus).toBe(ProviderStatus.READY);
   });

--- a/package.json
+++ b/package.json
@@ -10,27 +10,26 @@
   "scripts": {
     "test": "jest test/",
     "test:e2e": "jest e2e/",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "build": "yarn lint && tsc"
   },
   "peerDependencies": {
-    "@openfeature/core": "^1.9.0",
     "@openfeature/server-sdk": "^1.19.0",
-    "bkt-node-server-sdk": "^0.4.2"
+    "@bucketeer/node-server-sdk": "^0.4.2"
   },
   "devDependencies": {
+    "@openfeature/core": "^1.9.0",
+    "@openfeature/server-sdk": "^1.19.0",
+    "@bucketeer/node-server-sdk": "^0.4.2",
     "@eslint/js": "^9.8.0",
-    "@openfeature/core": "1.9.0",
-    "@openfeature/server-sdk": "1.19.0",
     "@types/eslint": "^9.6.0",
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
-    "bkt-node-server-sdk": "^0.4.1",
     "dotenv": "^16.6.1",
     "eslint": "^9.8.0",
     "eslint-config-prettier": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@openfeature/core": "^1.9.0",
     "@openfeature/server-sdk": "^1.19.0",
-    "@bucketeer/node-server-sdk": "^0.4.2",
+    "@bucketeer/node-server-sdk": "^0.4.3",
     "@eslint/js": "^9.8.0",
     "@types/eslint": "^9.6.0",
     "@types/eslint__js": "^8.42.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { BucketeerProvider } from './internal/BucketeerProvider';
 
-export * from 'bkt-node-server-sdk';
+export * from '@bucketeer/node-server-sdk';
 export { BucketeerProvider };
 export { SDK_VERSION } from './internal/version';

--- a/src/internal/BKTEvaluationDetailExt.ts
+++ b/src/internal/BKTEvaluationDetailExt.ts
@@ -1,5 +1,5 @@
 import { JsonValue, ResolutionDetails } from '@openfeature/server-sdk';
-import { BKTEvaluationDetails, BKTValue } from 'bkt-node-server-sdk';
+import { BKTEvaluationDetails, BKTValue } from '@bucketeer/node-server-sdk';
 
 function toResolutionDetails<T extends BKTValue>(
   evaluationDetails: BKTEvaluationDetails<T>,

--- a/src/internal/BucketeerProvider.ts
+++ b/src/internal/BucketeerProvider.ts
@@ -12,7 +12,12 @@ import {
   ServerProviderEvents,
 } from '@openfeature/server-sdk';
 
-import { BKTConfig, Bucketeer, defineBKTConfig, initializeBKTClient } from '@bucketeer/node-server-sdk';
+import {
+  BKTConfig,
+  Bucketeer,
+  defineBKTConfig,
+  initializeBKTClient,
+} from '@bucketeer/node-server-sdk';
 
 import { SDK_VERSION } from './version';
 import { evaluationContextToBKTUser } from './EvaluationContext';

--- a/src/internal/BucketeerProvider.ts
+++ b/src/internal/BucketeerProvider.ts
@@ -1,5 +1,4 @@
 import {
-  ErrorCode,
   EvaluationContext,
   Hook,
   InvalidContextError,
@@ -11,10 +10,9 @@ import {
   ProviderNotReadyError,
   ResolutionDetails,
   ServerProviderEvents,
-  StandardResolutionReasons,
 } from '@openfeature/server-sdk';
 
-import { BKTConfig, Bucketeer, defineBKTConfig, initializeBKTClient } from 'bkt-node-server-sdk';
+import { BKTConfig, Bucketeer, defineBKTConfig, initializeBKTClient } from '@bucketeer/node-server-sdk';
 
 import { SDK_VERSION } from './version';
 import { evaluationContextToBKTUser } from './EvaluationContext';

--- a/src/internal/EvaluationContext.ts
+++ b/src/internal/EvaluationContext.ts
@@ -1,4 +1,4 @@
-import { User } from 'bkt-node-server-sdk';
+import { User } from '@bucketeer/node-server-sdk';
 import {
   EvaluationContext,
   EvaluationContextValue,

--- a/test/BKTEvaluationDetailExt.test.ts
+++ b/test/BKTEvaluationDetailExt.test.ts
@@ -2,7 +2,7 @@ import {
   toResolutionDetails,
   toResolutionDetailsJsonValue,
 } from '../src/internal/BKTEvaluationDetailExt';
-import { BKTEvaluationDetails, BKTValue } from 'bkt-node-server-sdk';
+import { BKTEvaluationDetails, BKTValue } from '@bucketeer/node-server-sdk';
 import { JsonValue, ResolutionDetails } from '@openfeature/server-sdk';
 
 describe('toResolutionDetails', () => {

--- a/test/BucketeerProvider.test.ts
+++ b/test/BucketeerProvider.test.ts
@@ -10,7 +10,7 @@ import {
   Bucketeer,
   defineBKTConfig,
   initializeBKTClient,
-} from 'bkt-node-server-sdk';
+} from '@bucketeer/node-server-sdk';
 import {
   EvaluationContext,
   InvalidContextError,
@@ -21,10 +21,10 @@ import {
   JsonValue,
 } from '@openfeature/server-sdk';
 import { SDK_VERSION } from '../src/internal/version';
-import { InternalConfig } from 'bkt-node-server-sdk/lib/internalConfig';
+import { InternalConfig } from '@bucketeer/node-server-sdk/lib/internalConfig';
 
-jest.mock('bkt-node-server-sdk', () => {
-  const actualImpl = jest.requireActual('bkt-node-server-sdk');
+jest.mock('@bucketeer/node-server-sdk', () => {
+  const actualImpl = jest.requireActual('@bucketeer/node-server-sdk');
   return {
     ...actualImpl,
     initializeBKTClient: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bucketeer/evaluation@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/@bucketeer/evaluation/-/evaluation-0.0.4.tgz"
-  integrity sha512-pFDbx/QOqbSlWIyOJ6X8mP2gIPJYrDYcWWzCYLOzpcQ6HzxYSdP7jGwIkseEhsqu+mfHaO+yxz/vwLTHv+9B4A==
+"@bucketeer/evaluation@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.5.tgz#5e0a9e181cc09fe3b2ec231c0b51d91e9ba5b85a"
+  integrity sha512-qZf/wh7hXdS3IBV0TmmXKbNBfbvg5/Clrb7hTryEAdihp5zsimEo9JYiCZ17x8sCKEKd8d7nMb4+gNl35mpTYw==
   dependencies:
     "@improbable-eng/grpc-web" "^0.15.0"
     "@types/fnv-plus" "^1.3.2"
@@ -283,6 +283,19 @@
     fnv-plus "^1.3.1"
     google-protobuf "3.14.0"
     murmurhash3js "^3.0.1"
+
+"@bucketeer/node-server-sdk@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@bucketeer/node-server-sdk/-/node-server-sdk-0.4.2.tgz#496df17a698d7392924f4ce769fbc7e5275d8462"
+  integrity sha512-bTtGaRRpt1Nz+a+vgXfgOjA9cjL0YV1xMLPlc1q/ps5KI5tnGXcNJWS0QJZklX2Q/1pDxpTXoro/RrO0jD09Yg==
+  dependencies:
+    "@bucketeer/evaluation" "0.0.5"
+    "@improbable-eng/grpc-web" "^0.15.0"
+    "@improbable-eng/grpc-web-node-http-transport" "^0.15.0"
+    "@types/node" "^22.15.35"
+    "@types/uuid" "^10.0.0"
+    google-protobuf "^3.21.4"
+    uuid "^11.1.0"
 
 "@esbuild/aix-ppc64@0.23.1":
   version "0.23.1"
@@ -469,12 +482,12 @@
 
 "@improbable-eng/grpc-web-node-http-transport@^0.15.0":
   version "0.15.0"
-  resolved "https://registry.npmjs.org/@improbable-eng/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.15.0.tgz"
+  resolved "https://registry.yarnpkg.com/@improbable-eng/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.15.0.tgz#5a064472ef43489cbd075a91fb831c2abeb09d68"
   integrity sha512-HLgJfVolGGpjc9DWPhmMmXJx8YGzkek7jcCFO1YYkSOoO81MWRZentPOd/JiKiZuU08wtc4BG+WNuGzsQB5jZA==
 
 "@improbable-eng/grpc-web@^0.15.0":
   version "0.15.0"
-  resolved "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.15.0.tgz"
+  resolved "https://registry.yarnpkg.com/@improbable-eng/grpc-web/-/grpc-web-0.15.0.tgz#3e47e9fdd90381a74abd4b7d26e67422a2a04bef"
   integrity sha512-ERft9/0/8CmYalqOVnJnpdDry28q+j+nAlFFARdjyxXDJ+Mhgv9+F600QC8BR9ygOfrXRlAk6CvST2j+JCpQPg==
   dependencies:
     browser-headers "^0.4.1"
@@ -742,15 +755,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openfeature/core@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.npmjs.org/@openfeature/core/-/core-1.9.0.tgz"
-  integrity sha512-pbJM8bD9yApOzZDEF5njL0A3B1bbT+DHtyCbYVCf5NOVGR6nNWiQaWFcQwrbvfOx9pvVm770/uRfBCzdL2XAUA==
+"@openfeature/core@^1.9.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@openfeature/core/-/core-1.9.1.tgz#9925a04ed0745e92dd7b3793b35cff1ed89d54c1"
+  integrity sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==
 
-"@openfeature/server-sdk@1.19.0":
-  version "1.19.0"
-  resolved "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz"
-  integrity sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==
+"@openfeature/server-sdk@^1.19.0":
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/@openfeature/server-sdk/-/server-sdk-1.20.0.tgz#43a5d3cffd915742ff64eeef53b7132279df4823"
+  integrity sha512-95L9CCaGVKC6+7rNCmDxjthFvUyPLOUkoYyjg9Y/Cmy0G9D63xrJBsmH6fqHtLifzAu4+E7fWAZ3TIBnnCtr7A==
 
 "@pkgr/core@^0.1.0":
   version "0.1.1"
@@ -831,12 +844,12 @@
 
 "@types/fnv-plus@^1.3.2":
   version "1.3.2"
-  resolved "https://registry.npmjs.org/@types/fnv-plus/-/fnv-plus-1.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/@types/fnv-plus/-/fnv-plus-1.3.2.tgz#bd591c1031ae48a18c99eaa60f659288aea545c0"
   integrity sha512-Bgr5yn2dph2q8HZKDS002Pob6vaRTRfhqN9E+TOhjKsJvnfZXULPR3ihH8dL5ZjgxbNhqhTn9hijpbAMPtKZzw==
 
 "@types/google-protobuf@^3.15.12":
   version "3.15.12"
-  resolved "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.12.tgz#eb2ba0eddd65712211a2b455dc6071d665ccf49b"
   integrity sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==
 
 "@types/graceful-fs@^4.1.3":
@@ -880,7 +893,7 @@
 
 "@types/murmurhash3js@^3.0.7":
   version "3.0.7"
-  resolved "https://registry.npmjs.org/@types/murmurhash3js/-/murmurhash3js-3.0.7.tgz"
+  resolved "https://registry.yarnpkg.com/@types/murmurhash3js/-/murmurhash3js-3.0.7.tgz#5c3589180f13aac082857932ffb353251e7f296b"
   integrity sha512-jN3Z37nILIW1DZyP6N/NK+aw/zjFHPVb7hjrmdw7jx7FayrhKgkNpo6ZDwAsH8HSANjebBOxoXXtA39gKwyeGw==
 
 "@types/node@*":
@@ -890,16 +903,16 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^22.15.3":
-  version "22.18.1"
-  resolved "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz"
-  integrity sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==
+"@types/node@^22.15.35":
+  version "22.19.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.1.tgz#1188f1ddc9f46b4cc3aec76749050b4e1f459b7b"
+  integrity sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==
   dependencies:
     undici-types "~6.21.0"
 
 "@types/semver@^7.5.8":
   version "7.7.1"
-  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
 "@types/stack-utils@^2.0.0":
@@ -909,7 +922,7 @@
 
 "@types/uuid@^10.0.0":
   version "10.0.0"
-  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
   integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
 
 "@types/yargs-parser@*":
@@ -1218,19 +1231,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bkt-node-server-sdk@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/bkt-node-server-sdk/-/bkt-node-server-sdk-0.4.1.tgz"
-  integrity sha512-IYIsGe05Is2EuzCj1Ogm7n+iRA2s0gvgOmh6gOKV6ZOC6g4kETgr+Fj5kjT5lVkyTVjsgfXRgDSTE4g5pL2tBQ==
-  dependencies:
-    "@bucketeer/evaluation" "0.0.4"
-    "@improbable-eng/grpc-web" "^0.15.0"
-    "@improbable-eng/grpc-web-node-http-transport" "^0.15.0"
-    "@types/node" "^22.15.3"
-    "@types/uuid" "^10.0.0"
-    google-protobuf "^3.21.4"
-    uuid "^11.1.0"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
@@ -1255,7 +1255,7 @@ braces@^3.0.3:
 
 browser-headers@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/browser-headers/-/browser-headers-0.4.1.tgz#4308a7ad3b240f4203dbb45acedb38dc2d65dd02"
   integrity sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==
 
 browserslist@^4.24.0:
@@ -1743,7 +1743,7 @@ flatted@^3.2.9:
 
 fnv-plus@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.npmjs.org/fnv-plus/-/fnv-plus-1.3.1.tgz"
+  resolved "https://registry.yarnpkg.com/fnv-plus/-/fnv-plus-1.3.1.tgz#c34cb4572565434acb08ba257e4044ce2b006d67"
   integrity sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw==
 
 fs.realpath@^1.0.0:
@@ -1821,12 +1821,12 @@ globals@^14.0.0:
 
 google-protobuf@3.14.0:
   version "3.14.0"
-  resolved "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.14.0.tgz"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.14.0.tgz#20373d22046e63831a5110e11a84f713cc43651e"
   integrity sha512-bwa8dBuMpOxg7COyqkW6muQuvNnWgVN8TX/epDRGW5m0jcrmq2QJyCyiV8ZE2/6LaIIqJtiv9bYokFhfpy/o6w==
 
 google-protobuf@^3.21.4:
   version "3.21.4"
-  resolved "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.4.tgz#2f933e8b6e5e9f8edde66b7be0024b68f77da6c9"
   integrity sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==
 
 graceful-fs@^4.2.9:
@@ -2556,7 +2556,7 @@ ms@^2.1.3:
 
 murmurhash3js@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
   integrity sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==
 
 natural-compare@^1.4.0:
@@ -3058,7 +3058,7 @@ undici-types@~6.19.2:
 
 undici-types@~6.21.0:
   version "6.21.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 update-browserslist-db@^1.1.3:
@@ -3078,7 +3078,7 @@ uri-js@^4.2.2:
 
 uuid@^11.1.0:
   version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 v8-to-istanbul@^9.0.1:


### PR DESCRIPTION
This pull request updates the SDK dependency from `bkt-node-server-sdk` to `@bucketeer/node-server-sdk` throughout the codebase and test files. It also makes improvements to linting and ensures that the SDK version is properly checked in tests. These changes help standardize the SDK import, improve code quality, and ensure version consistency.

**SDK dependency migration:**

* All imports of `bkt-node-server-sdk` have been replaced with `@bucketeer/node-server-sdk` in source files 

* The `package.json` dependencies and peerDependencies have been updated to use `@bucketeer/node-server-sdk` instead of `bkt-node-server-sdk`.

**Linting and code quality:**

* The `lint` script in `package.json` now uses `--max-warnings=0` to enforce stricter linting.

**Testing improvements:**

* The e2e test now checks that `SDK_VERSION` is defined, ensuring version consistency between the provider and the SDK.