### PR TITLE
deps: update @bucketeer/node-server-sdk to v0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.19.0",
-    "@bucketeer/node-server-sdk": "^0.4.2"
+    "@bucketeer/node-server-sdk": "^0.4.4"
   },
   "devDependencies": {
     "@openfeature/core": "^1.9.0",
     "@openfeature/server-sdk": "^1.19.0",
-    "@bucketeer/node-server-sdk": "^0.4.3",
+    "@bucketeer/node-server-sdk": "^0.4.4",
     "@eslint/js": "^9.8.0",
     "@types/eslint": "^9.6.0",
     "@types/eslint__js": "^8.42.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bucketeer/evaluation@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.5.tgz#5e0a9e181cc09fe3b2ec231c0b51d91e9ba5b85a"
-  integrity sha512-qZf/wh7hXdS3IBV0TmmXKbNBfbvg5/Clrb7hTryEAdihp5zsimEo9JYiCZ17x8sCKEKd8d7nMb4+gNl35mpTYw==
+"@bucketeer/evaluation@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.6.tgz#28a2a3271f0a256661450eb8b0227147519495bf"
+  integrity sha512-Ve7e81Lz6INrpa8dxhEzaUz3fXN5jQGQE1K4Vj88l+NarNst/ksmvEiqYkhrH1tHjszd7TxCir9tTTGg8VLWqQ==
   dependencies:
     "@improbable-eng/grpc-web" "^0.15.0"
     "@types/fnv-plus" "^1.3.2"
@@ -282,18 +282,17 @@
     "@types/semver" "^7.5.8"
     fnv-plus "^1.3.1"
     google-protobuf "3.14.0"
+    js-yaml "^4.1.0"
     murmurhash3js "^3.0.1"
 
-"@bucketeer/node-server-sdk@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@bucketeer/node-server-sdk/-/node-server-sdk-0.4.2.tgz#496df17a698d7392924f4ce769fbc7e5275d8462"
-  integrity sha512-bTtGaRRpt1Nz+a+vgXfgOjA9cjL0YV1xMLPlc1q/ps5KI5tnGXcNJWS0QJZklX2Q/1pDxpTXoro/RrO0jD09Yg==
+"@bucketeer/node-server-sdk@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@bucketeer/node-server-sdk/-/node-server-sdk-0.4.4.tgz#eed878d5aef1161caaabe61f01749fa2581d7f1b"
+  integrity sha512-VKY2mRHxfpAVt7UInUX8l59AFGLwOt5JOHLUs7R1Z6KKaD3FdPbM3/r1BCqdRHHPYUKyyBlsc6QGNH23rL+LEg==
   dependencies:
-    "@bucketeer/evaluation" "0.0.5"
+    "@bucketeer/evaluation" "0.0.6"
     "@improbable-eng/grpc-web" "^0.15.0"
     "@improbable-eng/grpc-web-node-http-transport" "^0.15.0"
-    "@types/node" "^22.15.35"
-    "@types/uuid" "^10.0.0"
     google-protobuf "^3.21.4"
     uuid "^11.1.0"
 
@@ -903,13 +902,6 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^22.15.35":
-  version "22.19.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.1.tgz#1188f1ddc9f46b4cc3aec76749050b4e1f459b7b"
-  integrity sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==
-  dependencies:
-    undici-types "~6.21.0"
-
 "@types/semver@^7.5.8":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
@@ -919,11 +911,6 @@
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
-
-"@types/uuid@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
-  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -3055,11 +3042,6 @@ undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
-
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 update-browserslist-db@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Bumped @bucketeer/node-server-sdk in peer and dev dependencies from v0.4.2/v0.4.3 to v0.4.4. This also updates related transitive dependencies in yarn.lock, including @bucketeer/evaluation.