### PR TITLE
fix: align equals/in semver fallback behavior with comparison operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.19.0",
-    "@bucketeer/node-server-sdk": "^0.4.4"
+    "@bucketeer/node-server-sdk": "^0.4.5"
   },
   "devDependencies": {
     "@openfeature/core": "^1.9.0",
     "@openfeature/server-sdk": "^1.19.0",
-    "@bucketeer/node-server-sdk": "^0.4.4",
+    "@bucketeer/node-server-sdk": "^0.4.5",
     "@eslint/js": "^9.8.0",
     "@types/eslint": "^9.6.0",
     "@types/eslint__js": "^8.42.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bucketeer/evaluation@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.6.tgz#28a2a3271f0a256661450eb8b0227147519495bf"
-  integrity sha512-Ve7e81Lz6INrpa8dxhEzaUz3fXN5jQGQE1K4Vj88l+NarNst/ksmvEiqYkhrH1tHjszd7TxCir9tTTGg8VLWqQ==
+"@bucketeer/evaluation@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.7.tgz#40cc0a9c55dad5e340d3730ffa3efd4022bb44ca"
+  integrity sha512-S18IoJ0Dg9lKUDjqX5M55CupmWAXD62Pyhl0ACTjHuH4PrPl44fgL1BGaIuPhirJsG/LdWRuTP03Jkwmq5X/GA==
   dependencies:
     "@improbable-eng/grpc-web" "^0.15.0"
     "@types/fnv-plus" "^1.3.2"
@@ -285,12 +285,12 @@
     js-yaml "^4.1.0"
     murmurhash3js "^3.0.1"
 
-"@bucketeer/node-server-sdk@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@bucketeer/node-server-sdk/-/node-server-sdk-0.4.4.tgz#eed878d5aef1161caaabe61f01749fa2581d7f1b"
-  integrity sha512-VKY2mRHxfpAVt7UInUX8l59AFGLwOt5JOHLUs7R1Z6KKaD3FdPbM3/r1BCqdRHHPYUKyyBlsc6QGNH23rL+LEg==
+"@bucketeer/node-server-sdk@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@bucketeer/node-server-sdk/-/node-server-sdk-0.4.5.tgz#212645995533ba117ab2d658ad0843b22004d6ed"
+  integrity sha512-NeSrI4XxL3wAmT4U+RfOK7gR5b4tHlxIIk88WSq95Pm9ltbChy+3E58OXkYNeConT5hQ+8zLkEI5+WWJDBkbRA==
   dependencies:
-    "@bucketeer/evaluation" "0.0.6"
+    "@bucketeer/evaluation" "0.0.7"
     "@improbable-eng/grpc-web" "^0.15.0"
     "@improbable-eng/grpc-web-node-http-transport" "^0.15.0"
     google-protobuf "^3.21.4"


### PR DESCRIPTION
Updating the bucketeer module to fix this [issue](https://github.com/bucketeer-io/bucketeer/issues/2354) related to semVer when using as flag rules.