### PR TITLE
feat: await client destroy on provider close

### DIFF
--- a/src/internal/BucketeerProvider.ts
+++ b/src/internal/BucketeerProvider.ts
@@ -187,7 +187,7 @@ export class BucketeerProvider implements Provider {
         this.events.emit(ServerProviderEvents.Ready);
       } else {
         this.events.emit(ServerProviderEvents.Error);
-        throw new ProviderFatalError(`Failed to initialize Bucketeer client: ${error}`);
+        throw new ProviderFatalError(`Failed to initialize Bucketeer client: ${String(error)}`);
       }
     }
   }
@@ -203,7 +203,7 @@ export class BucketeerProvider implements Provider {
     try {
       await client?.destroy();
     } catch (error) {
-      throw new GeneralError(`Failed to close Bucketeer client: ${error}`, {
+      throw new GeneralError(`Failed to close Bucketeer client: ${String(error)}`, {
         cause: error,
       });
     }

--- a/src/internal/BucketeerProvider.ts
+++ b/src/internal/BucketeerProvider.ts
@@ -192,8 +192,15 @@ export class BucketeerProvider implements Provider {
   }
 
   async onClose() {
-    await this.client?.destroy();
-    this.client = undefined;
+    // Re-initializing a provider after/while closing is not a supported flow, so we
+    // don't guard against a concurrent initialize() replacing the client here.
+    try {
+      await this.client?.destroy();
+    } finally {
+      // Clear the reference even if destroy() rejects (e.g. shutdown timeout), so a
+      // stale, already-destroyed client can't leak out through requiredBKTClient().
+      this.client = undefined;
+    }
   }
 
   requiredBKTClient(): Bucketeer {

--- a/src/internal/BucketeerProvider.ts
+++ b/src/internal/BucketeerProvider.ts
@@ -192,7 +192,7 @@ export class BucketeerProvider implements Provider {
   }
 
   async onClose() {
-    this.client?.destroy();
+    await this.client?.destroy();
     this.client = undefined;
   }
 

--- a/src/internal/BucketeerProvider.ts
+++ b/src/internal/BucketeerProvider.ts
@@ -1,6 +1,7 @@
 import {
   ErrorCode,
   EvaluationContext,
+  GeneralError,
   Hook,
   InvalidContextError,
   JsonValue,
@@ -192,14 +193,19 @@ export class BucketeerProvider implements Provider {
   }
 
   async onClose() {
-    // Re-initializing a provider after/while closing is not a supported flow, so we
-    // don't guard against a concurrent initialize() replacing the client here.
+    // Detach the client before awaiting teardown so the provider becomes
+    // unavailable immediately: a concurrent requiredBKTClient() during shutdown
+    // fails fast instead of using a client that's mid-destroy. Detaching first
+    // also guarantees a rejecting destroy() can't leave a stale, already-destroyed
+    // client referenced.
+    const client = this.client;
+    this.client = undefined;
     try {
-      await this.client?.destroy();
-    } finally {
-      // Clear the reference even if destroy() rejects (e.g. shutdown timeout), so a
-      // stale, already-destroyed client can't leak out through requiredBKTClient().
-      this.client = undefined;
+      await client?.destroy();
+    } catch (error) {
+      throw new GeneralError(`Failed to close Bucketeer client: ${error}`, {
+        cause: error,
+      });
     }
   }
 

--- a/test/BucketeerProvider.test.ts
+++ b/test/BucketeerProvider.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@bucketeer/node-server-sdk';
 import {
   EvaluationContext,
+  GeneralError,
   InvalidContextError,
   ProviderFatalError,
   ProviderNotReadyError,
@@ -444,13 +445,16 @@ describe('BucketeerProvider', () => {
       expect(provider['client']).toBeUndefined();
     });
 
-    it('should clear the client even if destroy() rejects', async () => {
+    it('should clear the client and wrap the error if destroy() rejects', async () => {
       const timeoutError = new Error('shutdown timed out');
       timeoutError.name = 'TimeoutError';
       mockClient.destroy.mockRejectedValueOnce(timeoutError);
 
-      await expect(provider.onClose()).rejects.toBe(timeoutError);
-      // The finally block must still clear the stale, destroyed client.
+      const closePromise = provider.onClose();
+      await expect(closePromise).rejects.toBeInstanceOf(GeneralError);
+      await expect(closePromise).rejects.toHaveProperty('cause', timeoutError);
+
+      // The reference is detached even though destroy() rejected.
       expect(provider['client']).toBeUndefined();
       expect(() => provider.requiredBKTClient()).toThrow(ProviderNotReadyError);
     });

--- a/test/BucketeerProvider.test.ts
+++ b/test/BucketeerProvider.test.ts
@@ -67,7 +67,7 @@ describe('BucketeerProvider', () => {
       numberVariationDetails: jest.fn(),
       objectVariationDetails: jest.fn(),
       waitForInitialization: jest.fn(),
-      destroy: jest.fn(),
+      destroy: jest.fn().mockResolvedValue(undefined),
       getBoolVariation: jest.fn(),
       getStringVariation: jest.fn(),
       getNumberVariation: jest.fn(),
@@ -442,6 +442,17 @@ describe('BucketeerProvider', () => {
       await provider.onClose();
       expect(mockClient.destroy).toHaveBeenCalled();
       expect(provider['client']).toBeUndefined();
+    });
+
+    it('should clear the client even if destroy() rejects', async () => {
+      const timeoutError = new Error('shutdown timed out');
+      timeoutError.name = 'TimeoutError';
+      mockClient.destroy.mockRejectedValueOnce(timeoutError);
+
+      await expect(provider.onClose()).rejects.toBe(timeoutError);
+      // The finally block must still clear the stale, destroyed client.
+      expect(provider['client']).toBeUndefined();
+      expect(() => provider.requiredBKTClient()).toThrow(ProviderNotReadyError);
     });
 
     it('should throw ProviderNotReadyError if BKTClient is not initialized', () => {


### PR DESCRIPTION
## What

Await `client.destroy()` in `BucketeerProvider.onClose()` so the client's shutdown completes before the reference is cleared.

## Why

The Bucketeer Node SDK made `destroy()` asynchronous in **v0.4.4** (bucketeer-io/node-server-sdk#142, "add graceful shutdown with event batching"). It now returns `Promise<void>` and awaits flushing of any remaining batched events before tearing down.

Our `onClose()` still called it without `await`, so the promise was dropped: `onClose()` could resolve while shutdown was still in flight, and buffered events could be lost — defeating the graceful shutdown.

Awaiting it ensures teardown fully completes (and any rejection surfaces) before `this.client` is set to `undefined`.

## Changes

- `await this.client?.destroy()` in `onClose()`


That changes also fixed some warning logs in the e2e tests

<img width="900" alt="Screenshot 2026-06-26 at 16 20 54" src="https://github.com/user-attachments/assets/f610260d-8c7a-4f74-a7e7-f486b2cf9f2a" />

https://github.com/bucketeer-io/openfeature-node-server-sdk/actions/runs/28215594592/job/83585916633