### PR TITLE
ci: augment changelog with node-server-sdk dependency changes

### DIFF
--- a/.github/dependency-changelog.config.json
+++ b/.github/dependency-changelog.config.json
@@ -1,0 +1,25 @@
+{
+  "sectionTitle": "Node Server SDK Changes",
+  "sectionIntro": "This release also brings the following changes from the underlying Node.js server SDK.",
+  "dependencies": [
+    {
+      "name": "Node Server SDK",
+      "shortName": "node-server-sdk",
+      "repo": "bucketeer-io/node-server-sdk",
+      "versionFile": "package.json",
+      "versionRegex": "\"devDependencies\"[\\s\\S]*?\"@bucketeer/node-server-sdk\":\\s*\"\\^?([0-9][^\"]*)\""
+    }
+  ],
+  "skipPatterns": [
+    "^\\*\\*deps:\\*\\*\\s+update\\s+all\\s+non-major\\s+dependencies"
+  ],
+  "sectionOrder": [
+    "Features",
+    "Bug Fixes",
+    "Performance Improvements",
+    "Reverts",
+    "Refactoring",
+    "Miscellaneous",
+    "Build System"
+  ]
+}

--- a/.github/scripts/augment-changelog.mjs
+++ b/.github/scripts/augment-changelog.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+// Augments CHANGELOG.md with dependency SDK release notes for the topmost release.
+//
+// Reads .github/dependency-changelog.config.json to learn which dependency files
+// to inspect, fetches GitHub release bodies for every dependency version between
+// the base ref (typically main) and HEAD, aggregates them by section, and
+// splices a "Dependency Changes" block under the latest release heading.
+//
+// The block is enclosed in sentinel HTML comments so it can be removed and
+// regenerated cleanly on every run (idempotent across release-please force
+// pushes).
+//
+// Usage:
+//   node .github/scripts/augment-changelog.mjs --base-ref origin/main
+//
+// Env:
+//   GH_TOKEN  GitHub token used by the `gh` CLI to fetch release bodies.
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import process from "node:process";
+
+const CONFIG_PATH = ".github/dependency-changelog.config.json";
+const CHANGELOG_PATH = "CHANGELOG.md";
+const SENTINEL_START = "<!-- dependency-changes:start -->";
+const SENTINEL_END = "<!-- dependency-changes:end -->";
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+}
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseSemver(v) {
+  const cleaned = String(v).replace(/^v/, "").trim();
+  const match = cleaned.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return String(a).localeCompare(String(b));
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+async function readVersion(filePath, regex, ref) {
+  let content;
+  if (ref) {
+    try {
+      content = git(["show", `${ref}:${filePath}`]);
+    } catch (err) {
+      throw new Error(`Could not read ${filePath} at ${ref}: ${err.message}`);
+    }
+  } else {
+    content = await fs.readFile(filePath, "utf8");
+  }
+  const m = content.match(new RegExp(regex));
+  if (!m) {
+    throw new Error(`Could not match ${regex} in ${filePath}${ref ? ` at ${ref}` : ""}`);
+  }
+  return m[1];
+}
+
+function fetchReleasesBetween(repo, fromVersion, toVersion) {
+  // GitHub Releases via gh CLI. Walk the most recent 100 releases and filter
+  // to (fromVersion, toVersion]. 100 is enough for any wrapper SDK that bumps
+  // a few times per year; bump if needed.
+  const raw = gh([
+    "release",
+    "list",
+    "--repo",
+    repo,
+    "--limit",
+    "100",
+    "--json",
+    "tagName,name,publishedAt",
+  ]);
+  const releases = JSON.parse(raw);
+  const inRange = releases
+    .map((r) => ({ ...r, version: r.tagName.replace(/^v/, "") }))
+    .filter((r) => parseSemver(r.version))
+    .filter((r) => compareSemver(r.version, fromVersion) > 0 && compareSemver(r.version, toVersion) <= 0)
+    .sort((a, b) => compareSemver(b.version, a.version));
+
+  // Fetch bodies one-by-one so we don't pull bodies for unrelated releases.
+  for (const r of inRange) {
+    const body = gh([
+      "release",
+      "view",
+      r.tagName,
+      "--repo",
+      repo,
+      "--json",
+      "body",
+      "--jq",
+      ".body",
+    ]);
+    r.body = body || "";
+  }
+  return inRange;
+}
+
+function parseReleaseBody(body) {
+  // release-please bodies look like:
+  //   ### Features
+  //
+  //   * item one ([#1](url))
+  //   * item two
+  //
+  //   ### Bug Fixes
+  //   ...
+  //
+  // Be lenient: accept ## or ### headings (release-please uses ###), and
+  // accept either `*` or `-` bullets.
+  const sections = {};
+  const lines = body.split(/\r?\n/);
+  let current = null;
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\s+$/, "");
+    const heading = line.match(/^#{2,4}\s+(.+?)\s*$/);
+    if (heading) {
+      const title = heading[1].trim();
+      // Skip anchor headings like the version range header that release-please
+      // sometimes emits at the top of a body (it does not for our setup, but
+      // safe to ignore non-section ones if encountered).
+      current = title;
+      sections[current] ??= [];
+      continue;
+    }
+    if (!current) continue;
+    const bullet = line.match(/^\s*[-*]\s+(.+)$/);
+    if (bullet) {
+      sections[current].push(bullet[1].trim());
+    }
+  }
+  // Drop empty sections.
+  for (const k of Object.keys(sections)) {
+    if (sections[k].length === 0) delete sections[k];
+  }
+  return sections;
+}
+
+function aggregateSections(releases) {
+  const all = {};
+  for (const r of releases) {
+    const sections = parseReleaseBody(r.body || "");
+    for (const [name, items] of Object.entries(sections)) {
+      all[name] ??= [];
+      for (const item of items) {
+        if (!all[name].includes(item)) all[name].push(item);
+      }
+    }
+  }
+  return all;
+}
+
+function rewriteItem(item, native) {
+  // 1. Strip the trailing commit-hash link release-please appends, e.g.
+  //    " ([abc1234](https://github.com/.../commit/abc1234...))".
+  let out = item.replace(
+    /\s*\(\[[0-9a-f]{6,40}\]\(https:\/\/github\.com\/[^)]+\/commit\/[0-9a-f]+\)\)\s*$/,
+    "",
+  );
+
+  // 2. Disambiguate bare issue refs by prefixing with the dependency repo's
+  //    short name. Only rewrite when the URL points to the dependency repo so
+  //    we don't accidentally rewrite cross-repo links.
+  const repoEsc = escapeRegex(native.repo);
+  const issueRefRegex = new RegExp(
+    `\\[#(\\d+)\\]\\((https://github\\.com/${repoEsc}/(?:issues|pull)/\\d+)\\)`,
+    "g",
+  );
+  out = out.replace(issueRefRegex, `[${native.shortName}#$1]($2)`);
+
+  return out.trim();
+}
+
+function renderNativeSection(native, fromVersion, toVersion, sections, config) {
+  const compareUrl = `https://github.com/${native.repo}/compare/v${fromVersion}...v${toVersion}`;
+  const lines = [];
+  lines.push(`#### ${native.name} ([v${fromVersion}...v${toVersion}](${compareUrl}))`);
+  lines.push("");
+
+  const skipPatterns = (config.skipPatterns || []).map((p) => new RegExp(p));
+  const ordered = config.sectionOrder || [];
+  const seen = new Set();
+  const emitSection = (name, items) => {
+    const filtered = items
+      .map((it) => rewriteItem(it, native))
+      .filter((it) => it.length > 0)
+      .filter((it) => !skipPatterns.some((re) => re.test(it)));
+    if (filtered.length === 0) return;
+    seen.add(name);
+    lines.push(`##### ${name}`);
+    lines.push("");
+    for (const item of filtered) {
+      lines.push(`* ${item}`);
+    }
+    lines.push("");
+  };
+
+  for (const name of ordered) {
+    if (sections[name]) emitSection(name, sections[name]);
+  }
+  // Emit any unexpected sections after the configured order, alphabetised.
+  for (const name of Object.keys(sections).sort()) {
+    if (seen.has(name)) continue;
+    emitSection(name, sections[name]);
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function spliceIntoChangelog(changelog, augmentation) {
+  // Drop any existing sentinel block first so we always start from the
+  // release-please-generated baseline. This is what makes the workflow safe
+  // to re-run after release-please force-pushes.
+  const sentinelRegex = new RegExp(
+    `\\n*${escapeRegex(SENTINEL_START)}[\\s\\S]*?${escapeRegex(SENTINEL_END)}\\n*`,
+    "g",
+  );
+  let cleaned = changelog.replace(sentinelRegex, "\n");
+
+  // Find the topmost `## ` heading (the new release).
+  const firstHeadingMatch = cleaned.match(/^## .+$/m);
+  if (!firstHeadingMatch) {
+    throw new Error("Could not find a release heading (`## ...`) in CHANGELOG.md");
+  }
+  const firstHeadingIdx = cleaned.indexOf(firstHeadingMatch[0]);
+  const afterFirstHeading = firstHeadingIdx + firstHeadingMatch[0].length;
+
+  // Find the next `## ` heading (start of previous release).
+  const nextHeadingRegex = /\n## /g;
+  nextHeadingRegex.lastIndex = afterFirstHeading;
+  const nextMatch = nextHeadingRegex.exec(cleaned);
+  const insertionPoint = nextMatch ? nextMatch.index : cleaned.length;
+
+  const before = cleaned.slice(0, insertionPoint).replace(/\s+$/, "");
+  const after = cleaned.slice(insertionPoint);
+
+  const block = [
+    "",
+    "",
+    SENTINEL_START,
+    "",
+    augmentation,
+    SENTINEL_END,
+    "",
+  ].join("\n");
+
+  return `${before}${block}${after.startsWith("\n") ? after : `\n${after}`}`;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--base-ref") args.baseRef = argv[++i];
+    else if (a === "--config") args.configPath = argv[++i];
+    else if (a === "--changelog") args.changelogPath = argv[++i];
+    else if (a === "--dry-run") args.dryRun = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const baseRef = args.baseRef || "origin/main";
+  const configPath = args.configPath || CONFIG_PATH;
+  const changelogPath = args.changelogPath || CHANGELOG_PATH;
+
+  const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+  if (!Array.isArray(config.dependencies) || config.dependencies.length === 0) {
+    console.log("No dependency SDKs configured, nothing to do.");
+    return;
+  }
+
+  const augmentations = [];
+  for (const native of config.dependencies) {
+    const newVersion = await readVersion(native.versionFile, native.versionRegex);
+    let oldVersion;
+    try {
+      oldVersion = await readVersion(native.versionFile, native.versionRegex, baseRef);
+    } catch (err) {
+      console.warn(`[${native.name}] could not read base version, skipping: ${err.message}`);
+      continue;
+    }
+
+    if (compareSemver(newVersion, oldVersion) <= 0) {
+      console.log(`[${native.name}] no upgrade (${oldVersion} -> ${newVersion}), skipping`);
+      continue;
+    }
+
+    console.log(`[${native.name}] ${oldVersion} -> ${newVersion}, fetching release notes`);
+    let releases;
+    try {
+      releases = fetchReleasesBetween(native.repo, oldVersion, newVersion);
+    } catch (err) {
+      console.warn(`[${native.name}] failed to fetch releases: ${err.message}`);
+      continue;
+    }
+    if (releases.length === 0) {
+      console.warn(`[${native.name}] no GitHub releases found in (${oldVersion}, ${newVersion}], skipping`);
+      continue;
+    }
+    console.log(`[${native.name}] found ${releases.length} release(s): ${releases.map((r) => r.tagName).join(", ")}`);
+
+    const sections = aggregateSections(releases);
+    if (Object.keys(sections).length === 0) {
+      console.warn(`[${native.name}] release bodies contained no parseable sections, skipping`);
+      continue;
+    }
+    augmentations.push(renderNativeSection(native, oldVersion, newVersion, sections, config));
+  }
+
+  if (augmentations.length === 0) {
+    console.log("No dependency SDK upgrades found, leaving CHANGELOG.md untouched.");
+    return;
+  }
+
+  const sectionTitle = config.sectionTitle ?? "Dependency Changes";
+  const sectionIntro = config.sectionIntro ?? "This release also brings the following changes from the underlying dependency SDKs.";
+  const intro = [`### ${sectionTitle}`, "", sectionIntro].join("\n");
+  const fullBlock = `${intro}\n\n${augmentations.join("\n\n")}\n`;
+
+  const original = await fs.readFile(changelogPath, "utf8");
+  const updated = spliceIntoChangelog(original, fullBlock);
+
+  if (updated === original) {
+    console.log("CHANGELOG.md already up to date.");
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log("--- diff (dry run) ---");
+    console.log(updated);
+    return;
+  }
+
+  await fs.writeFile(changelogPath, updated);
+  console.log(`Updated ${changelogPath}.`);
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || String(err));
+  process.exit(1);
+});

--- a/.github/scripts/changelog-section.mjs
+++ b/.github/scripts/changelog-section.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Extracts a single release's section from CHANGELOG.md and prints it to stdout.
+//
+// release-please builds the GitHub Release body from the release PR notes (i.e.
+// the conventional commits it parsed), NOT from the committed CHANGELOG.md.
+// That means the "Dependency Changes" block injected by augment-changelog.mjs
+// never reaches the GitHub Release. This script lets the release workflow
+// re-sync the release body from the (already augmented) CHANGELOG.md.
+//
+// Usage:
+//   node .github/scripts/changelog-section.mjs --tag v2.2.2
+//   node .github/scripts/changelog-section.mjs --version 2.2.2 --changelog CHANGELOG.md
+//
+// Output:
+//   The body of the matching release section (heading line excluded so it
+//   mirrors release-please's own release-body format) with the dependency
+//   sentinel comments stripped.
+
+import fs from "node:fs/promises";
+import process from "node:process";
+
+const CHANGELOG_PATH = "CHANGELOG.md";
+const SENTINEL_START = "<!-- dependency-changes:start -->";
+const SENTINEL_END = "<!-- dependency-changes:end -->";
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--tag") args.tag = argv[++i];
+    else if (a === "--version") args.version = argv[++i];
+    else if (a === "--changelog") args.changelogPath = argv[++i];
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+function stripSentinels(text) {
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== SENTINEL_START && line.trim() !== SENTINEL_END)
+    .join("\n");
+}
+
+function extractSection(changelog, version) {
+  // release-please (release-type "simple") writes headings like:
+  //   ## [2.2.2](https://github.com/.../compare/v2.2.1...v2.2.2) (2026-06-18)
+  // Match the heading for the requested version, tolerating both linked
+  // (`## [x.y.z](...)`) and bare (`## x.y.z`) forms.
+  const v = escapeRegex(version);
+  const headingRegex = new RegExp(`^## \\[?${v}\\]?(?:[ (]|$)`, "m");
+  const headingMatch = changelog.match(headingRegex);
+  if (!headingMatch) {
+    throw new Error(`Could not find a CHANGELOG section for version ${version}`);
+  }
+
+  const headingIdx = headingMatch.index;
+  const afterHeading = headingIdx + headingMatch[0].length;
+  // Find the end of the heading line, then look for the next `## ` heading.
+  const lineEnd = changelog.indexOf("\n", afterHeading);
+  const bodyStart = lineEnd === -1 ? changelog.length : lineEnd + 1;
+
+  const nextHeadingRegex = /\n## /g;
+  nextHeadingRegex.lastIndex = bodyStart;
+  const nextMatch = nextHeadingRegex.exec(changelog);
+  const bodyEnd = nextMatch ? nextMatch.index : changelog.length;
+
+  return changelog.slice(bodyStart, bodyEnd);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const changelogPath = args.changelogPath || CHANGELOG_PATH;
+  const version = (args.version || args.tag || "").replace(/^v/, "").trim();
+  if (!version) {
+    throw new Error("Provide --tag or --version");
+  }
+
+  const changelog = await fs.readFile(changelogPath, "utf8");
+  const section = extractSection(changelog, version);
+  const body = stripSentinels(section).trim();
+
+  if (!body) {
+    throw new Error(`CHANGELOG section for version ${version} is empty`);
+  }
+
+  process.stdout.write(`${body}\n`);
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || String(err));
+  process.exit(1);
+});

--- a/.github/workflows/augment-release-please-changelog.yml
+++ b/.github/workflows/augment-release-please-changelog.yml
@@ -1,0 +1,80 @@
+# Augments release-please's auto-generated CHANGELOG.md with release notes
+# from the Node Server SDK whenever the release-please PR bumps its version.
+#
+# The script is idempotent (uses <!-- dependency-changes:start/end --> sentinel
+# HTML comments) so this workflow can safely re-run after release-please
+# force-pushes its branch.
+name: Augment release-please CHANGELOG
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: augment-changelog-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  augment:
+    # Only run on release-please branches that originate from THIS repo.
+    # release-please names its branches `release-please--branches--<base>`
+    # (or similar) so a prefix match is the most resilient check across
+    # plugin versions. The repo check prevents a forked PR that happens to
+    # reuse the same branch name from triggering this workflow (it would
+    # only get a read-only token and fail noisily at push time anyway).
+    if: >-
+      startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Fetch tags
+        run: git fetch --tags --force origin
+
+      - name: Determine previous release tag
+        id: previous
+        run: |
+          # The wrapper SDK PR that bumps the node-server-sdk version lands on
+          # `main` before release-please opens the release PR, so comparing
+          # against `main` would show no diff. Compare against the previous
+          # release tag instead (the most recent tag reachable from main).
+          PREV_TAG="$(git describe --tags --abbrev=0 "origin/${{ github.base_ref }}")"
+          echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous release tag: ${PREV_TAG}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Augment CHANGELOG.md with Node Server SDK changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/augment-changelog.mjs --base-ref "${{ steps.previous.outputs.tag }}"
+
+      - name: Commit and push if changed
+        run: |
+          if [[ -z "$(git status --porcelain CHANGELOG.md)" ]]; then
+            echo "No changes to CHANGELOG.md."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): augment with Node Server SDK release notes"
+          # Pushing with GITHUB_TOKEN does not retrigger workflows, so this
+          # cannot loop with itself. release-please pushes (using its PAT)
+          # will retrigger this workflow, and the script's sentinels make
+          # the augmentation re-apply cleanly.
+          git push origin "HEAD:${{ github.head_ref }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
+        id: release
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }} # PAT so the tag push by release-please triggers publish.yml
+
+      # release-please builds the GitHub Release body from the release PR notes,
+      # not from CHANGELOG.md, so the "Node Server SDK Changes" block added by the
+      # augment-changelog workflow never reaches the published release. Re-sync
+      # the release body from the (already augmented) CHANGELOG.md in the current ref.
+      - name: Checkout
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Sync GitHub Release notes from CHANGELOG.md
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: |
+          node .github/scripts/changelog-section.mjs --tag "${TAG_NAME}" > release-notes.md
+          gh release edit "${TAG_NAME}" --notes-file release-notes.md


### PR DESCRIPTION
## Summary

The `openfeature-node-server-sdk` is a thin proxy over `@bucketeer/node-server-sdk`.
When we ship a new version of the OpenFeature SDK, the most meaningful changes
often come from the underlying Node Server SDK — but those were invisible in the
CHANGELOG and GitHub Release notes.

This PR ports the same changelog-augmentation workflow already used by the Flutter
SDK (which merges iOS/Android notes) and adapts it for this repo:

- **`.github/dependency-changelog.config.json`** — declares `@bucketeer/node-server-sdk`
  as the tracked dependency, with the version read from `devDependencies` in `package.json`.
- **`.github/scripts/augment-changelog.mjs`** — on each release-please PR, detects
  whether the node-server-sdk version bumped, fetches GitHub Release notes for every
  version in the range, and splices a **"Node Server SDK Changes"** block into
  `CHANGELOG.md` under the new release heading (idempotent via
  `<!-- dependency-changes:start/end -->` sentinels).
- **`.github/scripts/changelog-section.mjs`** — extracts a single release's section
  from `CHANGELOG.md` (sentinels stripped) for use as the GitHub Release body.
- **`.github/workflows/augment-release-please-changelog.yml`** — triggers on
  release-please PRs, runs the augmentation, and commits back to the PR branch.
- **`.github/workflows/release.yml`** — updated to re-sync the GitHub Release body
  from the augmented `CHANGELOG.md` after release-please creates the release.